### PR TITLE
Remove dependency from activesupport

### DIFF
--- a/flyml.gemspec
+++ b/flyml.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", ">= 3.2.0"
-
   spec.add_development_dependency "bundler", ">= 1.9"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4"

--- a/lib/flyml/core_ext/hash.rb
+++ b/lib/flyml/core_ext/hash.rb
@@ -1,18 +1,36 @@
-require 'active_support/core_ext/hash/keys'
-
 class Hash
+  def symbolize_keys!
+    keys.each do |key|
+      new_key = begin
+        key.to_sym
+      rescue
+        key
+      end
+
+      self[new_key] = delete(key)
+    end
+  end
+
   def recursive_symbolize_keys!
     symbolize_keys!
+
     # symbolize each hash in .values
     values.each { |h| h.recursive_symbolize_keys! if h.is_a?(Hash) }
+
     # symbolize each hash inside an array in .values
-    values.select { |v| v.is_a?(Array) }.flatten.each { |h| h.recursive_symbolize_keys! if h.is_a?(Hash) }
+    values.
+      select { |v| v.is_a?(Array) }.
+      flatten.
+      each { |h| h.recursive_symbolize_keys! if h.is_a?(Hash) }
+
     self
   end
 
   def deep_fetch(*args, &block)
     return self if args.empty?
+
     value = fetch(args.shift, &block)
+
     if value.is_a?(Hash)
       value.deep_fetch(*args, &block)
     elsif value.is_a?(Array) && !args.empty?


### PR DESCRIPTION
Requiring all of activesupport just to "simbolize hash keys" is a bit of an overkill.

This patch implements simbolize_keys! in a Hash